### PR TITLE
feat: update vault-cli 1.14.3 -> 1.14.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 ENV VERSION_AWS_CLI="2.13.20"
 ENV VERSION_GH_CLI="2.35.0"
 ENV VERSION_RCLONE="1.63.1"
-ENV VERSION_VAULT="1.14.3"
+ENV VERSION_VAULT="1.14.4"
 ENV VERSION_LOKI="2.9.1"
 
 # Update the system and install required packages


### PR DESCRIPTION
I think this was missed. I saw 1.14.4 in the main helm chart