### PR TITLE
feat: update aws cli to v2.17.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use an official Ubuntu runtime as a parent image
 FROM ubuntu:22.04@sha256:340d9b015b194dc6e2a13938944e0d016e57b9679963fdeb9ce021daac430221
 
-ENV VERSION_AWS_CLI="2.17.6"
+ENV VERSION_AWS_CLI="2.17.13"
 ENV VERSION_GH_CLI="2.52.0"
 ENV VERSION_VAULT="1.14.10"
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated AWS CLI version from 2.17.6 to 2.17.13 in the Dockerfile.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update AWS CLI version in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Updated AWS CLI version from 2.17.6 to 2.17.13



</details>


  </td>
  <td><a href="https://github.com/GlueOps/backup-tools/pull/45/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

