### PR TITLE
feat: update github backup script to do all orgs that the user has access too

### DIFF
--- a/github-backup.sh
+++ b/github-backup.sh
@@ -23,7 +23,7 @@ while true; do
     fi
 
     # Append organizations to the all_orgs variable
-    all_orgs="$all_orgs\n$orgs"
+    all_orgs="$all_orgs,$orgs"
 
     # Increment the page number
     page=$((page + 1))
@@ -32,9 +32,8 @@ done
 
 echo "Full list to be backed up: $all_orgs"
 
-echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
-        #remove literal newlines
-        GITHUB_ORG_TO_BACKUP=$(printf "%s" "$GITHUB_ORG_TO_BACKUP" | sed 's/^\\n//; s/^[[:space:]]*//; s/[[:space:]]*$//')
+for GITHUB_ORG_TO_BACKUP in "$@"; do
+        echo "\n\n"
         echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
 
         repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -33,7 +33,8 @@ done
 echo "Full list to be backed up: $orgs"
 
 echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
-
+        #remove newlines
+        GITHUB_ORG_TO_BACKUP=$(echo "$GITHUB_ORG_TO_BACKUP" | tr -d '\n')
         echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
 
         repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -34,7 +34,7 @@ echo "Full list to be backed up: $orgs"
 
 echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
         #remove newlines
-        GITHUB_ORG_TO_BACKUP=$(echo "$GITHUB_ORG_TO_BACKUP" | tr -d '\n')
+        GITHUB_ORG_TO_BACKUP=$(printf "%s" "$GITHUB_ORG_TO_BACKUP" | tr -d '\n')
         echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
 
         repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -2,29 +2,56 @@
 
 set -e
 
-# Check if required variables are set
-if [[ -z "${GITHUB_ORG_TO_BACKUP}" ]]; then
-    echo "Error: GITHUB_ORG_TO_BACKUP is not set."
-    exit 1
-fi
-
 if [[ -z "${GITHUB_TOKEN}" ]]; then
     echo "Error: GITHUB_TOKEN is not set."
     exit 1
 fi
 
-repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')
 
-BACKUP_DATE=$(date '+%Y-%m-%d')
-BACKUP_LOCATION="github.com/$BACKUP_DATE/$GITHUB_ORG_TO_BACKUP"
-mkdir -p $BACKUP_LOCATION && cd $BACKUP_LOCATION
+# Initialize page number
+page=1
+all_orgs=""
 
-for repo in $repos; do
-    git clone --mirror https://$GITHUB_TOKEN@github.com/$repo.git
-    repo_name="${repo##*/}"
-    tar -czf "${repo_name}.tar.gz" "${repo_name}.git" && rm -rf "${repo_name}.git"
+# Loop until we get an empty response
+while true; do
+    # Fetch organizations for the current page
+    orgs=$(gh api "/user/orgs?page=$page" --jq '.[].login')
+
+    # Check if the response is empty, meaning no more orgs
+    if [ -z "$orgs" ]; then
+        break
+    fi
+
+    # Append organizations to the all_orgs variable
+    all_orgs="$all_orgs\n$orgs"
+
+    # Increment the page number
+    page=$((page + 1))
 done
 
-echo "Uploading everything to S3...."
-cd /app
-aws s3 cp --recursive github.com/ s3://${S3_BUCKET_NAME}/github.com/
+
+echo "Full list to be backed up: $orgs"
+
+echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
+
+        echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
+
+        repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')
+
+        BACKUP_DATE=$(date '+%Y-%m-%d')
+        BACKUP_LOCATION="github.com/$BACKUP_DATE/$GITHUB_ORG_TO_BACKUP"
+        mkdir -p $BACKUP_LOCATION && cd $BACKUP_LOCATION
+
+        for repo in $repos; do
+            git clone --mirror https://$GITHUB_TOKEN@github.com/$repo.git
+            repo_name="${repo##*/}"
+            tar -czf "${repo_name}.tar.gz" "${repo_name}.git" && rm -rf "${repo_name}.git"
+        done
+
+        echo "Uploading everything to S3...."
+        cd /app
+        aws s3 cp --recursive github.com/ s3://${S3_BUCKET_NAME}/github.com/
+
+
+        echo "FINISHED BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
+done

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -52,6 +52,7 @@ echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
         echo "Uploading everything to S3...."
         cd /app
         aws s3 cp --recursive github.com/ s3://${S3_BUCKET_NAME}/github.com/
+        rm -rf github.com/
 
 
         echo "FINISHED BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -33,8 +33,8 @@ done
 echo "Full list to be backed up: $orgs"
 
 echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
-        #remove newlines
-        GITHUB_ORG_TO_BACKUP=$(printf "%s" "$GITHUB_ORG_TO_BACKUP" | tr -d '\n')
+        #remove literal newlines
+        GITHUB_ORG_TO_BACKUP=$(printf "%s" "$GITHUB_ORG_TO_BACKUP" | sed 's/^\\n//; s/^[[:space:]]*//; s/[[:space:]]*$//')
         echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
 
         repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -52,7 +52,9 @@ IFS="$OLD_IFS"
 echo "Full list to be backed up: $all_orgs"
 
 for GITHUB_ORG_TO_BACKUP in "$@"; do
-        echo "\n\n"
+        echo ""
+        echo ""
+        
         echo "STARTING BACKUP OF: https://github.com/${GITHUB_ORG_TO_BACKUP}"
 
         repos=$(gh repo list $GITHUB_ORG_TO_BACKUP -L 100000 --json nameWithOwner -q '.[].nameWithOwner')

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -30,7 +30,7 @@ while true; do
 done
 
 
-echo "Full list to be backed up: $orgs"
+echo "Full list to be backed up: $all_orgs"
 
 echo "$all_orgs" | while IFS= read -r GITHUB_ORG_TO_BACKUP; do
         #remove literal newlines

--- a/github-backup.sh
+++ b/github-backup.sh
@@ -21,14 +21,33 @@ while true; do
     if [ -z "$orgs" ]; then
         break
     fi
+    
+    # Replace newlines with commas in the current page's orgs
+    orgs_comma=$(echo "$orgs" | paste -sd "," -)
 
-    # Append organizations to the all_orgs variable
-    all_orgs="$all_orgs,$orgs"
+    # Append current orgs to all_orgs with a comma separator
+    if [ -z "$all_orgs" ]; then
+        all_orgs="$orgs_comma"
+    else
+        all_orgs="$all_orgs,$orgs_comma"
+    fi
 
     # Increment the page number
     page=$((page + 1))
 done
 
+
+# Save the original IFS
+OLD_IFS="$IFS"
+
+# Set IFS to comma for splitting
+IFS=','
+
+# Read the all_orgs into positional parameters
+set -- $all_orgs
+
+# Restore the original IFS
+IFS="$OLD_IFS"
 
 echo "Full list to be backed up: $all_orgs"
 


### PR DESCRIPTION
### **User description**
feat: update github backup script to do all orgs that the user has access too


___

### **PR Type**
enhancement


___

### **Description**
- Updated the GitHub backup script to support backing up all organizations that a user has access to, instead of a single specified organization.
- Implemented pagination to handle fetching of all organizations in case of large numbers.
- Modified the backup process to iterate through each organization and backup their repositories.
- Improved logging to indicate the start and finish of each organization's backup process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github-backup.sh</strong><dd><code>Enhance GitHub backup script to support multiple organizations</code></dd></summary>
<hr>

github-backup.sh

<li>Removed single organization backup logic.<br> <li> Added logic to backup all organizations a user has access to.<br> <li> Implemented pagination to fetch all organizations.<br> <li> Enhanced backup process to iterate through multiple organizations.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/backup-tools/pull/72/files#diff-17aaeb1c2924458bcdc1a30197bfaa8ae3cd7962440e1d564112d96a98ad55da">+44/-17</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information