### PR TITLE
feat: consolidate dependency updates

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -23,13 +23,13 @@ jobs:
 
           
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -48,7 +48,7 @@ jobs:
             type=sha,format=long,prefix=
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 # renovate: datasource=github-tags depName=aws/aws-cli
-ARG VERSION_AWS_CLI=2.34.0
+ARG VERSION_AWS_CLI=2.34.57
 # renovate: datasource=github-tags depName=cli/cli
-ARG VERSION_GH_CLI=2.87.3
+ARG VERSION_GH_CLI=2.93.0
 # renovate: datasource=github-tags depName=openbao/openbao
-ARG VERSION_OPENBAO=2.4.4
+ARG VERSION_OPENBAO=2.5.4
 # renovate: datasource=github-tags depName=grafana/loki
-ARG VERSION_LOKI=2.9.17
+ARG VERSION_LOKI=3.7.2
 
 # Update the system and install required packages
 RUN apt-get update -y && \
@@ -29,8 +29,8 @@ RUN curl --proto =https "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${
     rm -rf awscliv2.zip aws
 
 # renovate: datasource=github-tags depName=openbao/openbao
-ARG VERSION_OPENBAO=2.4.4
-  
+ARG VERSION_OPENBAO=2.5.4
+
 #Download and install Bao
 ADD https://github.com/openbao/openbao/releases/download/v${VERSION_OPENBAO}/bao_${VERSION_OPENBAO}_Linux_x86_64.tar.gz /tmp/bao_${VERSION_OPENBAO}_Linux_x86_64.tar.gz
 


### PR DESCRIPTION
## Summary
Bundles all 14 open Renovate PRs into one validated change.

### Included bumps

**`Dockerfile`** ARGs:
| Tool | From | To | Supersedes |
|---|---|---|---|
| aws/aws-cli | 2.34.0 | 2.34.57 | #221 |
| cli/cli | 2.87.3 | 2.93.0 | #233, #225, #223, #222, #220, #219 |
| openbao/openbao | 2.4.4 | 2.5.4 (both ARG declarations) | #207 |
| grafana/loki | 2.9.17 | 3.7.2 | #208 |

**`.github/workflows/container_image.yaml`** (SHA-pinned action bumps):
| Action | From | To | Supersedes |
|---|---|---|---|
| docker/setup-qemu-action | v3 | v4.1.0 | #214 |
| docker/setup-buildx-action | v3.12.0 | v4.1.0 | #215 |
| docker/login-action | v3.7.0 | v4.2.0 | #213 |
| docker/metadata-action | v5.10.0 | v6.1.0 | #216 |
| docker/build-push-action | v6.19.2 | v7.2.0 | #217 |

### Validation (in Docker)
- `docker build .` succeeds.
- Installed binaries report expected versions: `logcli 3.7.2`, `OpenBao v2.5.4`, `gh 2.93.0`, `aws-cli/2.34.57`.

### Excluded
None — all 14 open bot PRs are folded in.

## Test plan
- [ ] CI green on this PR (note: the docker/* action major bumps run for the first time on this workflow)
- [ ] Verify `Publish to GHCR.io` workflow still succeeds when a tag is cut after merge (the build-push v6 → v7 jump is the riskiest action change)