### PR TITLE
fix: restore resolved 'latest' to its own pre-restore snapshot

### DIFF
--- a/.github/workflows/test_nfs_backup.yml
+++ b/.github/workflows/test_nfs_backup.yml
@@ -1,0 +1,75 @@
+name: test-nfs-backup
+
+# Builds the image and runs both NFS backup/restore suites.
+#
+# These exercise real backup and DESTRUCTIVE restore paths against a real restic
+# repository, so they need the built image rather than a linter. Everything runs
+# inside the container against local/loopback repositories -- no network, no
+# credentials, no external storage.
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'nfs-backup.sh'
+      - 'nfs-restore.sh'
+      - 'restic-common.sh'
+      - 'test-nfs-backup/**'
+      - '.github/workflows/test_nfs_backup.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'nfs-backup.sh'
+      - 'nfs-restore.sh'
+      - 'restic-common.sh'
+      - 'test-nfs-backup/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Shell syntax check
+        run: |
+          for f in nfs-backup.sh nfs-restore.sh restic-common.sh \
+                   test-nfs-backup/e2e-test.sh test-nfs-backup/backend-test.sh; do
+            bash -n "$f" && echo "ok  $f"
+          done
+
+      # Advisory. Kept visible rather than blocking: RESTIC_EXTRA_OPTS is
+      # deliberately left unquoted so the caller can pass several -o options,
+      # which shellcheck flags as SC2086 by design.
+      - name: shellcheck (advisory)
+        continue-on-error: true
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          # SC1091: restic-common.sh is sourced from an absolute in-image path.
+          shellcheck -e SC1091 nfs-backup.sh nfs-restore.sh restic-common.sh
+
+      - name: Build image
+        run: docker build -t backup-tools-test .
+
+      - name: Backend, preflight and SFTP suite
+        run: |
+          docker run --rm \
+            -v "$PWD/test-nfs-backup/backend-test.sh:/bt.sh:ro" \
+            backup-tools-test bash -c '
+              apt-get update -qq >/dev/null 2>&1
+              apt-get install -y -qq openssh-sftp-server openssh-client >/dev/null 2>&1
+              bash /bt.sh'
+
+      - name: Backup/restore behaviour and metadata-fidelity suite
+        run: |
+          docker run --rm \
+            -v "$PWD/test-nfs-backup/e2e-test.sh:/e2e.sh:ro" \
+            backup-tools-test bash -c '
+              apt-get update -qq >/dev/null 2>&1
+              apt-get install -y -qq attr >/dev/null 2>&1
+              bash /e2e.sh'

--- a/nfs-backup.sh
+++ b/nfs-backup.sh
@@ -13,8 +13,9 @@
 #   RESTIC_KEEP_TAGS   comma-separated tags pinned against pruning (optional)
 #   HEARTBEAT_URL      external dead-man's switch, pinged on success (optional)
 #
-# NOTE ON FIDELITY: there are deliberately NO --exclude flags anywhere in this
-# script. The requirement is a complete backup. restic captures uid/gid, mode,
+# NOTE ON FIDELITY: the only --exclude is /data/.restore-staging, which is
+# scratch space written by restore-nfs, not user data. Nothing under the actual
+# export is ever excluded -- the requirement is a complete backup. restic captures uid/gid, mode,
 # setuid/setgid/sticky, symlinks, hardlinks, sparse content, timestamps and
 # user.* xattrs with no flags. (There is no xattr flag on `restic backup` at
 # all; --exclude-xattr / --include-xattr are restore-side filters.)
@@ -64,7 +65,14 @@ backup)
   fi
 
   rc=0
+  # The ONLY --exclude in this script, and it is not student data: `restore-nfs
+  # full stage` materialises a whole copy of the export into
+  # /data/.restore-staging. Backing that up doubles the snapshot's file count,
+  # and removing it halves it -- which trips the shrink guard below and pages
+  # someone with "possible data loss" one run after a staged restore, at the
+  # worst possible moment.
   restic "${ROPTS[@]}" backup /data \
+    --exclude /data/.restore-staging \
     --host "$HOSTTAG" \
     --tag daily \
     --no-scan \

--- a/nfs-restore.sh
+++ b/nfs-restore.sh
@@ -48,9 +48,16 @@ ALLOW_REPO_INIT=false ensure_repo
 # so every later message and confirmation token refers to one specific snapshot.
 resolve_snapshot() {
   local want="$1" id
+  # --host/--tag are ESSENTIAL, not cosmetic. This script writes `pre-restore`
+  # snapshots under the SAME host, so an unfiltered "latest" resolves to the
+  # safety snapshot taken by the PREVIOUS restore -- i.e. the student's damaged
+  # data -- and a second run of an identical command restores the damage over
+  # the good copy, reporting success. restic ignores these filters when an
+  # explicit snapshot id is given (it says so on stderr), so rolling back to a
+  # specific pre-restore id still works.
   # stderr is deliberately NOT swallowed: an S3 outage and a genuinely missing
   # snapshot must not both surface as "snapshot not found" during an incident.
-  id="$(restic "${ROPTS[@]}" snapshots --json "$want" | jq -r 'if length > 0 then .[-1].short_id else empty end')"
+  id="$(restic "${ROPTS[@]}" snapshots --host "$HOSTTAG" --tag daily --json "$want" | jq -r 'if length > 0 then .[-1].short_id else empty end')"
   [ -n "$id" ] || die "snapshot '$want' not found. Run in 'list' mode to see what exists."
   echo "$id"
 }
@@ -74,11 +81,22 @@ student)
       log "contents of '${RESTORE_STUDENT}' in the latest snapshot:"
       # Not `restic ls ... | head -50`: head exits at 50, restic takes SIGPIPE,
       # and pipefail propagates 141 -- so any student with >50 files printed
-      # their contents AND THEN "nothing found", which is the first thing an
-      # operator reads during an incident. Branch on restic's own status.
-      if restic "${ROPTS[@]}" ls latest "/data/${TERM_DIR}/${RESTORE_STUDENT}" > /tmp/ls.out 2>/tmp/ls.err; then
-        head -50 /tmp/ls.out
-        [ "$(wc -l < /tmp/ls.out)" -gt 50 ] && log "  ... ($(wc -l < /tmp/ls.out) entries total)"
+      # their contents AND THEN "nothing found".
+      #
+      # Branch on CONTENT, not exit status: `restic ls` exits 0 even for a path
+      # that does not exist in the snapshot, and always writes a one-line
+      # "snapshot ... filtered by [...]" header to stdout. Testing the status
+      # made the diagnostic unreachable, so a typo'd student name silently
+      # produced an empty listing with no explanation.
+      #
+      # --host/--tag for the same reason as resolve_snapshot: an unfiltered
+      # `latest` can be a pre-restore snapshot, giving a misleading view.
+      restic "${ROPTS[@]}" ls --host "$HOSTTAG" --tag daily latest \
+        "/data/${TERM_DIR}/${RESTORE_STUDENT}" > /tmp/ls.out 2>/tmp/ls.err || true
+      entries=$(( $(wc -l < /tmp/ls.out) - 1 ))   # line 1 is restic's header
+      if [ "$entries" -gt 0 ]; then
+        head -51 /tmp/ls.out
+        [ "$entries" -gt 50 ] && log "  ... (${entries} entries total)"
       else
         log "  (nothing found at that path — check the student name and term)"
         head -3 /tmp/ls.err >&2 || true
@@ -115,8 +133,10 @@ student)
       # cannot delete. This is the right answer for "I deleted my work".
       OVERWRITE="never"; DELETE=false; NEEDS_CONFIRM=false ;;
     overwrite)
-      # Also replaces files whose content differs. Keeps files the snapshot
-      # does not have. This PERMANENTLY REPLACES work created since the
+      # Also replaces files whose size OR mtime differs -- restic's if-changed
+      # is that heuristic, not a content comparison, so an edit that preserves
+      # both would be skipped. Keeps files the snapshot does not have.
+      # This PERMANENTLY REPLACES work created since the
       # snapshot -- it does not delete files, but it does destroy edits. The
       # pre-restore snapshot below is the only way back.
       OVERWRITE="if-changed"; DELETE=false; NEEDS_CONFIRM=false ;;

--- a/restic-common.sh
+++ b/restic-common.sh
@@ -108,13 +108,18 @@ prepare_backend_files() {
        RESTIC_EXTRA_OPTS and manage the connection yourself."
 
     local kh="${RESTIC_SSH_KNOWN_HOSTS:-}"
-    [ -n "$kh" ] && [ -r "$kh" ] || die "the sftp backend needs RESTIC_SSH_KNOWN_HOSTS
+    # Written as an explicit `if` rather than `A && B || C`: that form reads as
+    # if-then-else but is not one, and shellcheck flags it (SC2015). The logic
+    # here happened to be correct; spelling it out keeps it that way.
+    if [ -z "$kh" ] || [ ! -r "$kh" ]; then
+      die "the sftp backend needs RESTIC_SSH_KNOWN_HOSTS
        pointing at a readable known_hosts file, so the server's host key is
        PINNED. Generate it once with:
          ssh-keyscan -t ed25519 <host> > known_hosts
        and store it alongside the key. This is deliberately required: disabling
        host-key checking would let anything that can spoof DNS or occupy the
        route receive your backups."
+    fi
     cp "$kh" "$d/known_hosts" && chmod 644 "$d/known_hosts"
 
     # Passed through to ssh by restic. BatchMode makes a missing/rejected key

--- a/restic-common.sh
+++ b/restic-common.sh
@@ -253,21 +253,40 @@ restic_setup() {
 # it, and reports success; the shrink guard cannot catch it either, because it
 # reports "no previous snapshot -- first run".
 ensure_repo() {
-  if restic "${ROPTS[@]}" cat config >/dev/null 2>&1; then
-    return 0
-  fi
-  if [ "${ALLOW_REPO_INIT:-false}" != "true" ]; then
-    die "cannot open the repository at $(redact_repo).
-       This means ONE of: it does not exist yet, RESTIC_PASSWORD is wrong, or
-       the backend is unreachable. restic cannot tell these apart.
+  local err rc=0
+  err="$(restic "${ROPTS[@]}" cat config 2>&1 >/dev/null)" || rc=$?
 
-       If you are genuinely creating this repository for the first time, re-run
-       once with ALLOW_REPO_INIT=true, then REMOVE that setting.
+  # restic 0.19.1 DOES distinguish these (cmd/restic/main.go): 10 is raised only
+  # via ErrNoRepository when the backend reports genuine non-existence, and 12
+  # only via ErrNoKeyFound. Everything else -- refused connection, permission
+  # denied -- is a plain 1. Treating them alike previously meant a wrong
+  # password with ALLOW_REPO_INIT=true fell straight through to `restic init`.
+  case "$rc" in
+    0) return 0 ;;
+    12)
+      die "the repository at $(redact_repo) exists, but RESTIC_PASSWORD is WRONG.
+       Do NOT set ALLOW_REPO_INIT to work around this -- there is nothing to
+       create. Fix the password.
+       restic: ${err}"
+      ;;
+    10) : ;;   # genuinely absent: fall through to the init gate below
+    *)
+      die "cannot reach the backend for $(redact_repo) (restic exit ${rc}).
+       This is a connectivity or permissions problem, not a missing repository,
+       so ALLOW_REPO_INIT would not help.
+       restic: ${err}"
+      ;;
+  esac
+
+  if [ "${ALLOW_REPO_INIT:-false}" != "true" ]; then
+    die "no repository exists at $(redact_repo).
+       If you are genuinely creating it for the first time, re-run once with
+       ALLOW_REPO_INIT=true, then REMOVE that setting.
 
        Refusing to auto-create, because a typo in RESTIC_REPOSITORY would
        otherwise start a fresh empty backup history that reports success."
   fi
-  log "ALLOW_REPO_INIT=true and no readable repository -- running restic init"
+  log "ALLOW_REPO_INIT=true and no repository present -- running restic init"
   restic "${ROPTS[@]}" init
 }
 

--- a/test-nfs-backup/backend-test.sh
+++ b/test-nfs-backup/backend-test.sh
@@ -195,6 +195,79 @@ perm=$(stat -c %a /tmp/u1337/.restic-ssh/id 2>/dev/null)
 [ "$(stat -c %U /tmp/u1337/.restic-ssh/id 2>/dev/null)" != "root" ] \
   && ok "copy is owned by the running uid, not root" || bad "copy still root-owned"
 
+echo "=== 12. D1: a second restore must not resolve 'latest' to a pre-restore snapshot ==="
+export RESTIC_REPOSITORY=/tmp/d1repo RESTIC_PASSWORD=t BACKUP_HOST=h RESTORE_TERM=t1
+unset RESTIC_SSH_KEY RESTIC_SSH_KNOWN_HOSTS RESTIC_EXTRA_OPTS
+restic init -q >/dev/null 2>&1
+mkdir -p /data/t1/alice && echo "GOOD-WORK" > /data/t1/alice/thesis.txt
+restic backup /data --host h --tag daily --no-scan -q >/dev/null 2>&1
+echo GARBAGE1 > /data/t1/alice/thesis.txt
+RESTORE_MODE=overwrite RESTORE_STUDENT=alice restore-nfs student >/dev/null 2>&1
+[ "$(cat /data/t1/alice/thesis.txt)" = "GOOD-WORK" ] && ok "run 1 restored the daily snapshot" || bad "run 1 wrong"
+echo GARBAGE2 > /data/t1/alice/thesis.txt
+RESTORE_MODE=overwrite RESTORE_STUDENT=alice restore-nfs student >/dev/null 2>&1
+[ "$(cat /data/t1/alice/thesis.txt)" = "GOOD-WORK" ] \
+  && ok "run 2 also restored the daily, NOT run 1's pre-restore snapshot" \
+  || bad "run 2 restored DAMAGED data ($(cat /data/t1/alice/thesis.txt)) -- latest resolved to a pre-restore snapshot"
+
+PRE=$(restic snapshots --host h --tag pre-restore --json | jq -r ".[0].short_id")
+if RESTORE_MODE=exact RESTORE_STUDENT=alice RESTORE_SNAPSHOT_ID="$PRE" \
+     RESTORE_CONFIRM="restore-alice-${PRE}" restore-nfs student >/dev/null 2>&1; then
+  ok "an EXPLICIT pre-restore id is still usable for rollback"
+else bad "rollback to an explicit pre-restore id was broken by the filters"; fi
+
+echo "=== 13. D2: a typo'd student name is actually diagnosed ==="
+echo "GOOD-WORK" > /data/t1/alice/thesis.txt
+RESTORE_MODE=list RESTORE_STUDENT=nosuchstudent restore-nfs student >/tmp/l1.log 2>&1
+grep -q "nothing found at that path" /tmp/l1.log && ok "unknown student diagnosed" \
+  || bad "no diagnostic for an unknown student (restic ls exits 0 even when the path is absent)"
+RESTORE_MODE=list RESTORE_STUDENT=alice restore-nfs student >/tmp/l2.log 2>&1
+grep -q "thesis.txt" /tmp/l2.log && ok "a real student still lists their files" || bad "real student listing broken"
+grep -q "nothing found at that path" /tmp/l2.log && bad "false 'nothing found' for a real student" \
+  || ok "no false negative for a real student"
+
+echo "=== 14. D3: wrong password and unreachable backend are told apart ==="
+fails_with "wrong password is named as such" "RESTIC_PASSWORD is WRONG" \
+  RESTIC_REPOSITORY=/tmp/d1repo RESTIC_PASSWORD=DEFINITELYWRONG ALLOW_REPO_INIT=true
+fails_with "wrong password is not 'fixed' by ALLOW_REPO_INIT" "nothing to
+       create" \
+  RESTIC_REPOSITORY=/tmp/d1repo RESTIC_PASSWORD=DEFINITELYWRONG ALLOW_REPO_INIT=true
+# A backend error that is neither "missing" (10) nor "wrong password" (12).
+# Deliberately NOT a network target: restic retries connection failures with
+# backoff for minutes, so an unreachable host makes the suite look hung rather
+# than asserting anything. A permission-denied local path fails immediately with
+# exit 1, exercising the same branch. (It also has to run as non-root, since
+# root bypasses the permission check -- hence restore-nfs, which is the command
+# designed to run unprivileged.)
+mkdir -p /tmp/noperm/repo && chmod 000 /tmp/noperm
+install -d -o 1337 -g 1337 /tmp/u2 2>/dev/null || true
+out=$(setpriv --reuid=1337 --regid=1337 --clear-groups \
+      env PATH=/usr/local/bin:/usr/bin:/bin HOME=/tmp/u2 TMPDIR=/tmp/u2 \
+      RESTIC_REPOSITORY=/tmp/noperm/repo RESTIC_PASSWORD=t ALLOW_REPO_INIT=true \
+      BACKUP_HOST=h RESTORE_TERM=t1 RESTORE_MODE=list \
+      /usr/bin/restore-nfs student 2>&1) || true
+grep -q "cannot reach the backend" <<<"$out" \
+  && ok "a non-10/non-12 backend error is reported as such, not as a missing repo" \
+  || bad "backend error misreported: $(head -2 <<<"$out" | tr '\n' ' ')"
+chmod 755 /tmp/noperm
+
+echo "=== 15. D4: staged restores do not trip the shrink guard ==="
+export RESTIC_REPOSITORY=/tmp/d4repo ALLOW_REPO_INIT=true RESTIC_PASSWORD=t
+rm -rf /data/.restore-staging; mkdir -p /data/.backup-canary; rm -rf /canary; ln -s /data/.backup-canary /canary
+for i in $(seq 1 120); do echo x > /data/t1/alice/f$i; done
+backup-nfs backup >/dev/null 2>&1; backup-nfs backup >/dev/null 2>&1
+SNAP=$(restic snapshots --host h --tag daily --json | jq -r ".[-1].short_id")
+mkdir -p "/data/.restore-staging/$SNAP"
+restic restore "${SNAP}:/data" --target "/data/.restore-staging/$SNAP" -q >/dev/null 2>&1
+backup-nfs backup >/tmp/s1.log 2>&1 && ok "backup succeeds while a restore is staged" || { bad "backup failed with staging present"; tail -3 /tmp/s1.log; }
+rm -rf /data/.restore-staging
+if backup-nfs backup >/tmp/s2.log 2>&1; then
+  ok "backup succeeds after the staging dir is removed (no false data-loss alert)"
+else
+  bad "SHRINK GUARD FALSE POSITIVE after staging cleanup"; grep -E "file count|fell" /tmp/s2.log
+fi
+grep -q "restore-staging" /tmp/s2.log && bad "staging dir was backed up" || ok "staging dir excluded from the snapshot"
+
 echo
 echo "================= RESULT: $PASS passed, $FAIL failed ================="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Second-reader audit of #264/#265. Five defects, **all reproduced before fixing**. Plus CI, so these suites run on GitHub rather than only on a laptop.

## D1 — HIGH — a second restore silently restored the *damaged* data

`resolve_snapshot()` had no `--host`/`--tag` filter, and `restore-nfs` writes its own `pre-restore` safety snapshots **under the same host**. So `latest` resolved to the pre-restore snapshot taken by the *previous* restore — the student's damaged data — and a second run of an identical command restored that over the good copy:

```
run 1: snapshot=e79ab944  (the daily)              -> thesis = GOOD-WORK
run 2: snapshot=00856e1a  (run 1's pre-restore)    -> thesis = GARBAGE1
       RESTORE (overwrite) COMPLETE ... exit 0
```

`nfs-backup.sh` documents exactly this hazard for the shrink guard — the restore path missed it. `restic ls latest` in list mode had the same flaw, so the operator's *diagnostic* view was wrong too.

restic ignores those filters when an explicit snapshot id is given, so **rollback to a specific pre-restore id still works** — there's a test for that specifically, since it would have been an easy thing to break while fixing this.

## D2 — the "nothing found" diagnostic was unreachable code

`restic ls` exits **0** even when the path is absent from the snapshot, and always writes a one-line header to stdout. Branching on exit status meant a typo'd student name produced an empty listing with no explanation — during an incident. Now branches on content.

## D3 — "restic cannot tell these apart" was false, and hid a real hole

restic 0.19.1 returns **10** for a missing repository and **12** for a wrong password. Treating them alike meant a wrong password with `ALLOW_REPO_INIT=true` fell straight through to `restic init`. Now a wrong password is named as such and says explicitly that `ALLOW_REPO_INIT` will not help; any other error is reported as connectivity rather than a missing repository.

## D4 — staging a full restore triggered a false data-loss page

`full stage` materialises a copy of the export into `/data/.restore-staging` — **inside the backup source**. That doubles the snapshot's file count, and removing it halves it, so the shrink guard fired deterministically one run after an operator staged a restore, blaming an empty mount or a `root_squash` regression:

```
backup 2  file count: previous=105 current=105   OK
stage
backup 3  file count: previous=105 current=211   OK
rm -rf staging
backup 4  file count: previous=211 current=105   FATAL: fell >50%
```

The staging directory is now excluded. It's scratch space, not user data, so the no-excludes fidelity rule for the export still holds.

## D5 — comment accuracy

restic's `if-changed` compares size **and mtime**, not content, so `overwrite` can skip an edit preserving both. Reworded rather than changed — ordinary edits bump mtime.

## CI

`.github/workflows/test_nfs_backup.yml` builds the image and runs both suites on PRs touching these files. Everything runs inside the container against local and loopback repositories — no network, credentials or external storage. The SFTP tests drive a local `sftp-server` via `sftp.command`, so there's no server to stand up.

shellcheck is **advisory**, not blocking: `RESTIC_EXTRA_OPTS` is deliberately unquoted so callers can pass several `-o` options, which shellcheck flags as SC2086 by design. I'd rather that be visible than either blocking on intentional code or silently dropped.

## Tests

`backend-test.sh` 42 → **54 checks** with regression coverage for D1–D4. `e2e-test.sh` unchanged at **48**. CI on this PR is the first run of both under Actions — **54 + 48, all green**.

## Verified correct — recorded, not changed

Checked by execution and left alone, so they don't get re-litigated: `--host`/`--tag` genuinely constrain what `latest` resolves to for `restic stats`; the ISO-week bucket arithmetic never emits an out-of-range value; `--keep-tag`'s documented interaction with the surrounding `--tag daily` filter is accurate; and `restore <snap>:/data --target /data --delete` restores in place without deleting unrelated entries.

One test was also **rewritten rather than kept**: the "unreachable backend" case used a network target, but restic retries connection failures with backoff for minutes, so it made the suite look hung instead of asserting anything. It now uses a permission-denied local path, which fails immediately through the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM8CswSJktsdaWuPVuZ16r